### PR TITLE
[CHORE] adding instance filter node use method

### DIFF
--- a/internal/dashboards/node_exporter/node_exporter_cluster_use_method.go
+++ b/internal/dashboards/node_exporter/node_exporter_cluster_use_method.go
@@ -6,57 +6,79 @@ import (
 	panels "github.com/nicolastakashi/community-perses-dashboards/pkg/panels/node_exporter"
 	"github.com/perses/perses/go-sdk/dashboard"
 	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	labelValuesVar "github.com/perses/perses/go-sdk/prometheus/variable/label-values"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
 )
 
-func withClusterCPU(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+func withClusterCPU(datasource string, clusterLabelMatcher promql.LabelMatcher, instanceLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("CPU",
 		panelgroup.PanelsPerLine(2),
-		panels.ClusterNodeCPUUsagePercentage(datasource, labelMatcher),
-		panels.ClusterNodeCPUSaturationPercentage(datasource, labelMatcher),
+		panels.ClusterNodeCPUUsagePercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		panels.ClusterNodeCPUSaturationPercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }
 
-func withClusterMemory(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+func withClusterMemory(datasource string, clusterLabelMatcher promql.LabelMatcher, instanceLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Memory",
 		panelgroup.PanelsPerLine(2),
-		panels.ClusterNodeMemoryUsagePercentage(datasource, labelMatcher),
-		panels.ClusterNodeMemorySaturationPercentage(datasource, labelMatcher),
+		panels.ClusterNodeMemoryUsagePercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		panels.ClusterNodeMemorySaturationPercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }
 
-func withClusterNetwork(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+func withClusterNetwork(datasource string, clusterLabelMatcher promql.LabelMatcher, instanceLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Network",
 		panelgroup.PanelsPerLine(2),
-		panels.ClusterNodeNetworkUsageBytes(datasource, labelMatcher),
-		panels.ClusterNodeNetworkSaturationBytes(datasource, labelMatcher),
+		panels.ClusterNodeNetworkUsageBytes(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		panels.ClusterNodeNetworkSaturationBytes(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }
 
-func withClusterDiskIO(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+func withClusterDiskIO(datasource string, clusterLabelMatcher promql.LabelMatcher, instanceLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Disk IO",
 		panelgroup.PanelsPerLine(2),
-		panels.ClusterNodeDiskUsagePercentage(datasource, labelMatcher),
-		panels.ClusterNodeDiskSaturationPercentage(datasource, labelMatcher),
+		panels.ClusterNodeDiskUsagePercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		panels.ClusterNodeDiskSaturationPercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }
 
-func withClusterDiskSpace(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+func withClusterDiskSpace(datasource string, clusterLabelMatcher promql.LabelMatcher, instanceLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Disk Space",
 		panelgroup.PanelsPerLine(1),
-		panels.ClusterNodeDiskSpacePercentage(datasource, labelMatcher),
+		panels.ClusterNodeDiskSpacePercentage(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }
 
 func BuildNodeExporterClusterUseMethod(project string, datasource string, clusterLabelName string) (dashboard.Builder, error) {
 	clusterLabelMatcher := dashboards.GetClusterLabelMatcher(clusterLabelName)
+	instanceLabelMatcher := promql.LabelMatcher{
+		Name:  "instance",
+		Value: "$instance",
+		Type:  "=~",
+	}
 	return dashboard.New("node-exporter-cluster-use-method",
 		dashboard.ProjectName(project),
 		dashboard.Name("Node Exporter / USE Method / Cluster"),
 		dashboards.AddClusterVariable(datasource, clusterLabelName, "node_uname_info{job='node', sysname!='Darwin'}"),
-		withClusterCPU(datasource, clusterLabelMatcher),
-		withClusterMemory(datasource, clusterLabelMatcher),
-		withClusterNetwork(datasource, clusterLabelMatcher),
-		withClusterDiskIO(datasource, clusterLabelMatcher),
-		withClusterDiskSpace(datasource, clusterLabelMatcher),
+		dashboard.AddVariable("instance",
+			listVar.List(
+				labelValuesVar.PrometheusLabelValues("instance",
+					dashboards.AddVariableDatasource(datasource),
+					labelValuesVar.Matchers(
+						promql.SetLabelMatchers(
+							"node_uname_info{job='node', sysname!='Darwin'}",
+							[]promql.LabelMatcher{clusterLabelMatcher},
+						)),
+				),
+				listVar.DisplayName("instance"),
+				listVar.AllowAllValue(true),
+				listVar.AllowMultiple(true),
+			),
+		),
+		withClusterCPU(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		withClusterMemory(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		withClusterNetwork(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		withClusterDiskIO(datasource, clusterLabelMatcher, instanceLabelMatcher),
+		withClusterDiskSpace(datasource, clusterLabelMatcher, instanceLabelMatcher),
 	)
 }


### PR DESCRIPTION
This pull request to `internal/dashboards/node_exporter/node_exporter_cluster_use_method.go` includes changes to enhance the flexibility and accuracy of the node exporter cluster use method. The main updates involve adding an instance label matcher and modifying functions to accept both cluster and instance label matchers.

### Enhancements to label matching:

* Added imports for `labelValuesVar` and `listVar` to support new variable handling. (`internal/dashboards/node_exporter/node_exporter_cluster_use_method.go`)
* Modified `withClusterCPU`, `withClusterMemory`, `withClusterNetwork`, `withClusterDiskIO`, and `withClusterDiskSpace` functions to accept both `clusterLabelMatcher` and `instanceLabelMatcher` parameters. (`internal/dashboards/node_exporter/node_exporter_cluster_use_method.go`)
* Added a new instance label matcher in the `BuildNodeExporterClusterUseMethod` function to match the `instance` label. (`internal/dashboards/node_exporter/node_exporter_cluster_use_method.go`)

### Variable handling improvements:

* Introduced a new variable for `instance` using `listVar.List` and `labelValuesVar.PrometheusLabelValues` to allow dynamic selection of instances. (`internal/dashboards/node_exporter/node_exporter_cluster_use_method.go`) (F0