### PR TITLE
[FIX] prometheus overview instance var not loading

### DIFF
--- a/internal/dashboards/prometheus/prometheus_overview.go
+++ b/internal/dashboards/prometheus/prometheus_overview.go
@@ -71,8 +71,8 @@ func BuildPrometheusOverview(project string, datasource string, clusterLabelName
 				labelValuesVar.PrometheusLabelValues("instance",
 					labelValuesVar.Matchers(
 						promql.SetLabelMatchers(
-							"prometheus_remote_storage_shards",
-							[]promql.LabelMatcher{clusterLabelMatcher},
+							"prometheus_build_info",
+							[]promql.LabelMatcher{clusterLabelMatcher, {Name: "job", Type: "=", Value: "$job"}},
 						),
 					),
 					dashboards.AddVariableDatasource(datasource),


### PR DESCRIPTION
This pull request includes a change to the `internal/dashboards/prometheus/prometheus_overview.go` file to improve the Prometheus overview by updating the label matchers.

Improvements to Prometheus overview:

* [`internal/dashboards/prometheus/prometheus_overview.go`](diffhunk://#diff-960368e6a9516163c22c4c51622863da5e22739d96d688992d663d00d1eee056L74-R75): Modified the `BuildPrometheusOverview` function to use the `prometheus_build_info` metric and added a new label matcher for the `job` label.