### PR TITLE
[CHORE] making cluster label default empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	flag.StringVar(&project, "project", "default", "The project name")
 	flag.StringVar(&datasource, "datasource", "", "The datasource name")
-	flag.StringVar(&clusterLabelName, "cluster-label-name", "cluster", "The cluster label name")
+	flag.StringVar(&clusterLabelName, "cluster-label-name", "", "The cluster label name")
 	flag.Parse()
 
 	writer := dashboards.NewExec()


### PR DESCRIPTION
This pull request includes a small change to the `main.go` file. The change modifies the default value of the `cluster-label-name` flag to an empty string.

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L23-R23): Changed the default value of the `cluster-label-name` flag from `"cluster"` to an empty string.