### PR TITLE
[CHORE] adding demo env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,15 @@
 build-dashboards:
 	@echo "Building dashboards"
 	@go run main.go
+
+.PHONY: demo
+demo:
+	@echo "Setting up demo environment"
+
+	@cd ./examples && docker-compose up -d
+
+.PHONY: clean-demo
+clean-demo:
+	@echo "Cleaning up demo environment"
+
+	@cd ./examples && docker-compose down -v

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,0 @@
-version: "3"
-services:
-  perses:
-    image: persesdev/perses
-    container_name: perses
-    ports:
-      - "8080:8080"
-    restart: unless-stopped

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  perses:
+    image: persesdev/perses:v0.49-distroless-debug
+    container_name: perses
+    command: "--config=/etc/perses/config/config.yaml"
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    volumes:
+      - ./perses/config.yaml:/etc/perses/config/config.yaml
+      - ./perses/datasource.yaml:/etc/perses/resources/datasource.yaml
+      - ./perses/project.yaml:/etc/perses/resources/project.yaml

--- a/examples/perses/config.yaml
+++ b/examples/perses/config.yaml
@@ -1,0 +1,21 @@
+security:
+  readonly: false
+  enable_auth: false
+  cookie:
+    same_site: lax
+    secure: false
+
+database:
+  file:
+    extension: yaml
+    folder: /perses
+
+schemas:
+  datasources_path: /etc/perses/cue/schemas/datasources
+  interval: 5m
+  panels_path: /etc/perses/cue/schemas/panels
+  queries_path: /etc/perses/cue/schemas/queries
+  variables_path: /etc/perses/cue/schemas/variables
+provisioning:
+  folders:
+    - /etc/perses/resources

--- a/examples/perses/datasource.yaml
+++ b/examples/perses/datasource.yaml
@@ -1,0 +1,10 @@
+---
+kind: GlobalDatasource
+metadata:
+  name: PrometheusDemo
+spec:
+  default: true
+  plugin:
+    kind: PrometheusDatasource
+    spec:
+      directUrl: https://prometheus.demo.do.prometheus.io

--- a/examples/perses/project.yaml
+++ b/examples/perses/project.yaml
@@ -1,0 +1,6 @@
+kind: Project
+metadata:
+  name: mixin
+spec:
+  display:
+    name: "mixin"


### PR DESCRIPTION
This pull request introduces several changes to set up and manage a demo environment using Docker Compose, along with configuration files for the `perses` service. The most important changes include adding new demo-related commands to the `Makefile`, updating Docker Compose configurations, and adding new configuration and resource files for the `perses` service.

### Demo Environment Setup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R5-R16): Added `demo` and `clean-demo` targets to set up and clean the demo environment using Docker Compose.
* [`examples/docker-compose.yaml`](diffhunk://#diff-34686806ce7369ba8aea6b65936d44d3fe45a2799ac680b4f12741adaa0eed2bR1-R12): Introduced a new Docker Compose configuration for the `perses` service, specifying the image, command, ports, and volumes.

### Configuration Files:

* [`examples/perses/config.yaml`](diffhunk://#diff-9c01ae9f81aa9541fd52dc490bf57b7db52ff14ea42d02bfe1c1e2dd89bc0ef7R1-R21): Added a new configuration file for the `perses` service, detailing security settings, database configuration, and schema paths.
* [`examples/perses/datasource.yaml`](diffhunk://#diff-428353b78881fefb5ec2f84f7b3d2edbc539900590ab1e87abdaae784e42c35aR1-R10): Added a new datasource configuration file for `perses`, specifying a Prometheus datasource.
* [`examples/perses/project.yaml`](diffhunk://#diff-2877fe0dc1e6029021e0be20aac7d5cac65dda48a14ff95d24456ee5c6df85bdR1-R6): Added a new project configuration file for `perses`, defining project metadata and display settings.

### Cleanup:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L1-L8): Removed the old Docker Compose configuration file.