### PR TITLE
[DOCS] adding readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-dashboards:
 	@go run main.go
 
 .PHONY: demo
-demo:
+start-demo:
 	@echo "Setting up demo environment"
 
 	@cd ./examples && docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Perses Community Dashboards
+
+This repository hosts the code for Perses Community Dashboards, designed to serve as the Prometheus mixins for the Perses project. Built with the Perses Go SDK, these dashboards are modular, reusable, and easy to integrate.
+
+# Available Dashboards
+
+- Prometheus
+- Node Exporter
+- Alert Manager
+
+# Library Panels
+
+In addition to community dashboards, this repository also contains a library of reusable panels used to construct these dashboards. If you’re building custom dashboards and need a specific panel, you can leverage these library panels to create your own tailored setups.
+
+# Local Development
+
+To start local development, use the following command:
+
+```bash
+make start-demo
+```
+
+This will launch a local Perses instance with predefined resources like Project and DataSources. You can access the Perses UI at `http://localhost:8080`.

--- a/examples/perses/project.yaml
+++ b/examples/perses/project.yaml
@@ -1,6 +1,6 @@
 kind: Project
 metadata:
-  name: mixin
+  name: default
 spec:
   display:
-    name: "mixin"
+    name: "default"


### PR DESCRIPTION
This pull request includes several changes to improve the development workflow and documentation for the Perses Community Dashboards. The most important changes include updating the Makefile to rename a target, enhancing the README with detailed project information, and modifying the project configuration.

### Development Workflow Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7-R7): Renamed the `demo` target to `start-demo` to better reflect its purpose.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R23): Added detailed project information, including an overview of available dashboards, library panels, and instructions for local development.

### Configuration Updates:
* [`examples/perses/project.yaml`](diffhunk://#diff-2877fe0dc1e6029021e0be20aac7d5cac65dda48a14ff95d24456ee5c6df85bdL3-R6): Changed the project name from `mixin` to `default` to standardize the naming convention.