### PR TITLE
[REFACTORY] code consistency

### DIFF
--- a/examples/perses/datasource.yaml
+++ b/examples/perses/datasource.yaml
@@ -7,4 +7,4 @@ spec:
   plugin:
     kind: PrometheusDatasource
     spec:
-      directUrl: https://prometheus.demo.do.prometheus.io
+      directUrl: https://demo.promlabs.com

--- a/pkg/panels/alertmanager/alertmanager.go
+++ b/pkg/panels/alertmanager/alertmanager.go
@@ -14,6 +14,9 @@ import (
 // from Alertmanager using Prometheus as the data source. It generates a time series panel with
 // specific configurations for the Y-axis format and legend position.
 //
+// The panel uses the following Prometheus metrics:
+// - alertmanager_alerts: Current number of alerts stored in Alertmanager
+//
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
 //   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
@@ -22,7 +25,7 @@ import (
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func Alerts(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Alerts",
-		panel.Description("Current set of alerts stored in the Alertmanager"),
+		panel.Description("Shows current alerts in Alertmanager"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
@@ -37,14 +40,20 @@ func Alerts(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgr
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{instance}}"),
+				query.SeriesNameFormat("{{instance}} - Alertmanager - Alerts"),
 			),
 		),
 	)
 }
 
 // AlertsReceiveRate creates a panel option for displaying the rate of alerts received by the Alertmanager.
-// It includes a description of the panel, a time series chart with a legend, and a PromQL query to fetch the data.
+// The panel uses the following Prometheus metrics:
+// - alertmanager_alerts_received_total: Total number of alerts received
+// - alertmanager_alerts_invalid_total: Total number of invalid alerts received
+//
+// The panel shows:
+// - Rate of received alerts per instance
+// - Rate of invalid alerts per instance
 //
 // Parameters:
 //   - datasourceName: The name of the data source to be used for the query.
@@ -54,7 +63,7 @@ func Alerts(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgr
 //   - panelgroup.Option: The configured panel option.
 func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Alerts receive rate",
-		panel.Description("Rate of successful and invalid alerts received by the Alertmanager"),
+		panel.Description("Shows alert receive rate in Alertmanager"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
@@ -69,7 +78,7 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{instance}} Received"),
+				query.SeriesNameFormat("{{instance}} - Alertmanager - Received"),
 			),
 		),
 		panel.AddQuery(
@@ -79,7 +88,7 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{instance}} Invalid"),
+				query.SeriesNameFormat("{{instance}} - Alertmanager - Invalid"),
 			),
 		),
 	)
@@ -92,6 +101,14 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 // notifications sent and another for the failed notifications, both grouped by
 // integration and instance.
 //
+// The panel uses the following Prometheus metrics:
+// - alertmanager_notifications_total: Total count of notifications sent
+// - alertmanager_notifications_failed_total: Total count of failed notification attempts
+//
+// The panel shows:
+// - Rate of total notifications sent per integration
+// - Rate of failed notifications per integration
+//
 // Parameters:
 // - datasourceName: The name of the data source to be used for the queries.
 // - labelMatchers: A variadic parameter for Prometheus label matchers to filter the queries.
@@ -100,7 +117,7 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 // - panelgroup.Option: The configured panel option.
 func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Notifications Send Rate",
-		panel.Description("Rate of successful and invalid notifications sent by the Alertmanager"),
+		panel.Description("Shows notification send rate for the Alertmanager"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
@@ -115,7 +132,7 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ integration }} - {{instance}} Total"),
+				query.SeriesNameFormat("{{instance}} - {{integration}} - Total"),
 			),
 		),
 		panel.AddQuery(
@@ -125,7 +142,7 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ integration }} - {{instance}} Total"),
+				query.SeriesNameFormat("{{instance}} - {{integration}} - Failed"),
 			),
 		),
 	)
@@ -135,6 +152,16 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 // from Alertmanager. It generates a time series panel with queries for the 99th percentile,
 // median, and average notification latency.
 //
+// The panel uses the following Prometheus metrics:
+// - alertmanager_notification_latency_seconds_bucket: Histogram of notification latency
+// - alertmanager_notification_latency_seconds_sum: Total sum of notification latency
+// - alertmanager_notification_latency_seconds_count: Total count of notifications
+//
+// The panel shows:
+// - 99th percentile of notification latency
+// - Median notification latency
+// - Average notification latency
+//
 // Parameters:
 //   - datasourceName: The name of the data source to be used for the queries.
 //   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the metrics.
@@ -143,7 +170,7 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 //   - panelgroup.Option: An option that adds the configured panel to a panel group.
 func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Notification Duration",
-		panel.Description("Latency of notifications sent by the Alertmanager"),
+		panel.Description("Shows notification latency for the Alertmanager"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -163,7 +190,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ integration }} - {{instance}} 99th "),
+				query.SeriesNameFormat("{{instance}} - {{integration}} - 99th Percentile"),
 			),
 		),
 		panel.AddQuery(
@@ -173,7 +200,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ integration }} - {{instance}} Median"),
+				query.SeriesNameFormat("{{instance}} - {{integration}} - Median"),
 			),
 		),
 		panel.AddQuery(
@@ -183,7 +210,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ integration }} - {{instance}} Average"),
+				query.SeriesNameFormat("{{instance}} - {{integration}} - Average"),
 			),
 		),
 	)

--- a/pkg/panels/node_exporter/node_exporter.go
+++ b/pkg/panels/node_exporter/node_exporter.go
@@ -15,6 +15,13 @@ import (
 // of nodes using Prometheus as the data source. It generates a time series panel with
 // specific configurations for the Y-axis format and legend position.
 //
+// The panel uses the following Prometheus metrics:
+// - node_cpu_seconds_total: CPU time spent in different modes
+//
+// The panel shows:
+// - CPU usage percentage excluding idle, iowait, and steal time
+// - Breakdown by CPU core
+//
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
 //   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
@@ -23,10 +30,11 @@ import (
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func NodeCPUUsagePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("CPU Usage",
+		panel.Description("Shows CPU utilization percentage across cluster nodes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.PercentUnit),
+					Unit: string(commonSdk.PercentDecimalUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -42,28 +50,28 @@ func NodeCPUUsagePercentage(datasourceName string, labelMatchers ...promql.Label
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{cpu}}"),
+				query.SeriesNameFormat("{{device}} - CPU - Usage"),
 			),
 		),
 	)
 }
 
 // ClusterNodeCPUUsagePercentage creates a panel option for displaying the CPU usage percentage of cluster nodes.
-// It takes a datasource name and an optional list of Prometheus label matchers as arguments.
-// The panel displays a time series chart with the CPU usage percentage, formatted as a percentage unit.
-// The legend is positioned at the bottom and displayed in table mode, showing the last calculated value.
-// The PromQL query used calculates the CPU usage percentage by dividing the rate of CPU utilization by the total number of CPUs.
 //
-// The following Prometheus metrics are used:
-// - instance:node_cpu_utilisation:rate5m: The rate of CPU utilization over a 5-minute interval.
-// - instance:node_num_cpu:sum: The total number of CPUs.
+// The panel uses the following Prometheus metrics:
+// - instance:node_cpu_utilisation:rate5m: Rate of CPU utilization
+// - instance:node_num_cpu:sum: Total number of CPUs
+//
+// The panel shows:
+// - CPU usage percentage per instance
+// - Utilization relative to total available CPU cores
 //
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
+//   - labelMatchers: A variadic parameter for Prometheus label matchers.
 //
 // Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+//   - panelgroup.Option: The configured panel option.
 func ClusterNodeCPUUsagePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("CPU Usage",
 		timeSeriesPanel.Chart(
@@ -85,20 +93,24 @@ func ClusterNodeCPUUsagePercentage(datasourceName string, labelMatchers ...promq
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
-// ClusterNodeCPUSaturationPercentage creates a panel option for displaying the CPU saturation percentage
+// ClusterNodeCPUSaturationPercentage creates a panel option for displaying the CPU saturation percentage.
 // (Load1 per CPU) for cluster nodes. It takes a datasource name and an optional list of Prometheus label
 // matchers as arguments. The panel includes a time series chart with a percentage format on the Y-axis
 // and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
 // query used divides the instance load by the count of instances, filtering out zero values.
 //
-// The following Prometheus metrics are used:
-// - instance:node_load1_per_cpu:ratio: The ratio of the 1-minute load average per CPU.
+// The panel uses the following Prometheus metrics:
+// - instance:node_load1_per_cpu:ratio: Load average per CPU
+//
+// The panel shows:
+// - CPU saturation based on 1-minute load average
+// - Load per CPU across cluster nodes
 //
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
@@ -108,6 +120,7 @@ func ClusterNodeCPUUsagePercentage(datasourceName string, labelMatchers ...promq
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func ClusterNodeCPUSaturationPercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("CPU Saturation (Load1 per CPU)",
+		panel.Description("Shows CPU saturation metrics across cluster nodes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -127,29 +140,30 @@ func ClusterNodeCPUSaturationPercentage(datasourceName string, labelMatchers ...
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
 // ClusterNodeMemoryUsagePercentage creates a panel option for displaying the memory usage percentage of cluster nodes.
-// It takes a datasource name and an optional list of Prometheus label matchers as arguments.
-// The panel displays a time series chart with the memory usage percentage, formatted as a percentage unit.
-// The legend is positioned at the bottom and displayed in table mode, showing the last calculated value.
-// The PromQL query used calculates the memory usage percentage by dividing the used memory by the total memory.
 //
-// The following Prometheus metrics are used:
-// - instance:node_memory_utilisation:ratio: The ratio of memory utilization.
+// The panel uses the following Prometheus metrics:
+// - instance:node_memory_utilisation:ratio: Memory utilization ratio
+//
+// The panel shows:
+// - Memory usage percentage per instance
+// - Relative utilization across cluster nodes
 //
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
+//   - labelMatchers: A variadic parameter for Prometheus label matchers.
 //
 // Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+//   - panelgroup.Option: The configured panel option.
 func ClusterNodeMemoryUsagePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Memory Utilisation",
+		panel.Description("Shows memory utilization percentage across cluster nodes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -169,20 +183,24 @@ func ClusterNodeMemoryUsagePercentage(datasourceName string, labelMatchers ...pr
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
-// ClusterNodeMemorySaturationPercentage creates a panel option for displaying the memory saturation percentage
+// ClusterNodeMemorySaturationPercentage creates a panel option for displaying memory saturation.
 // (Major Page Faults) of cluster nodes. It takes a datasource name and an optional list of Prometheus label
 // matchers as arguments. The panel includes a time series chart with a reads per second format on the Y-axis
 // and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
 // query used calculates the rate of major page faults over a 5-minute interval.
 //
-// The following Prometheus metrics are used:
-// - instance:node_vmstat_pgmajfault:rate5m: The rate of major page faults over a 5-minute interval.
+// The panel uses the following Prometheus metrics:
+// - instance:node_vmstat_pgmajfault:rate5m: Rate of major page faults
+//
+// The panel shows:
+// - Memory saturation through page fault rate
+// - Page faults per second per node
 //
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
@@ -192,6 +210,7 @@ func ClusterNodeMemoryUsagePercentage(datasourceName string, labelMatchers ...pr
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func ClusterNodeMemorySaturationPercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Memory Saturation (Major Page Faults)",
+		panel.Description("Shows memory saturation through page fault metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -211,7 +230,7 @@ func ClusterNodeMemorySaturationPercentage(datasourceName string, labelMatchers 
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
@@ -223,8 +242,12 @@ func ClusterNodeMemorySaturationPercentage(datasourceName string, labelMatchers 
 // and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
 // query used calculates the disk usage percentage by dividing the rate of disk I/O time by the total number of disks.
 //
-// The following Prometheus metrics are used:
-// - instance_device:node_disk_io_time_seconds:rate5m: The rate of disk I/O time over a 5-minute interval.
+// The panel uses the following Prometheus metrics:
+// - instance_device:node_disk_io_time_seconds:rate5m: Rate of disk I/O time
+//
+// The panel shows:
+// - Disk I/O utilization percentage
+// - Usage patterns across different disks
 //
 // Parameters:
 //   - datasourceName: The name of the Prometheus data source.
@@ -234,6 +257,7 @@ func ClusterNodeMemorySaturationPercentage(datasourceName string, labelMatchers 
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func ClusterNodeDiskUsagePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Disk IO Utilisation",
+		panel.Description("Shows disk I/O utilization across cluster nodes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -253,29 +277,23 @@ func ClusterNodeDiskUsagePercentage(datasourceName string, labelMatchers ...prom
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
 // ClusterNodeDiskSaturationPercentage creates a panel option for displaying the disk I/O saturation
-// of cluster nodes. It takes a datasource name and an optional list of Prometheus label
-// matchers as arguments. The panel includes a time series chart with a percentage format on the Y-axis
-// and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
-// query used calculates the disk I/O saturation by dividing the weighted disk I/O time by the total number of disks.
+// of cluster nodes.
+// The panel uses the following Prometheus metrics:
+// - instance_device:node_disk_io_time_seconds:rate5m: Rate of disk I/O time
 //
-// The following Prometheus metrics are used:
-// - instance_device:node_disk_io_time_weighted_seconds:rate5m: The rate of weighted disk I/O time over a 5-minute interval.
-//
-// Parameters:
-//   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
-//
-// Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+// The panel shows:
+// - Disk I/O saturation per device
+// - Saturation patterns across nodes
 func ClusterNodeDiskSaturationPercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Disk IO Saturation",
+		panel.Description("Shows disk I/O saturation metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -291,34 +309,28 @@ func ClusterNodeDiskSaturationPercentage(datasourceName string, labelMatchers ..
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(instance_device:node_disk_io_time_weighted_seconds:rate5m{job='node'} / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job='node'}))) != 0",
+					"(instance_device:node_disk_io_time_seconds:rate5m{job='node'} / scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job='node'}))) != 0",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
 // ClusterNodeDiskSpacePercentage creates a panel option for displaying the disk space utilization
-// of cluster nodes. It takes a datasource name and an optional list of Prometheus label
-// matchers as arguments. The panel includes a time series chart with a percentage format on the Y-axis
-// and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
-// query used calculates the disk space utilization by dividing the used disk space by the total disk space.
+// of cluster nodes.
+// The panel uses the following Prometheus metrics:
+// - instance:node_filesystem_avail_bytes:sum: Available filesystem space
+// - instance:node_filesystem_size_bytes:sum: Total filesystem size
 //
-// The following Prometheus metrics are used:
-// - node_filesystem_size_bytes: The total size of the filesystem.
-// - node_filesystem_avail_bytes: The available size of the filesystem.
-//
-// Parameters:
-//   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
-//
-// Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+// The panel shows:
+// - Disk space utilization percentage
+// - Available vs total space ratio
 func ClusterNodeDiskSpacePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Disk Space Utilisation",
+		panel.Description("Shows disk space utilization metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -338,29 +350,23 @@ func ClusterNodeDiskSpacePercentage(datasourceName string, labelMatchers ...prom
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}}"),
 			),
 		),
 	)
 }
 
 // ClusterNodeNetworkSaturationBytes creates a panel option for displaying the network saturation
-// (Drops Receive/Transmit) of cluster nodes. It takes a datasource name and an optional list of Prometheus label
-// matchers as arguments. The panel includes a time series chart with a bytes per second format on the Y-axis
-// and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
-// query used calculates the rate of network drops over a 5-minute interval.
+// (Drops Receive/Transmit) of cluster nodes.
+// The panel uses the following Prometheus metrics:
+// - instance:node_network_receive_drop_excluding_lo:rate5m: Rate of network receive drops
 //
-// The following Prometheus metrics are used:
-// - instance:node_network_receive_drop_excluding_lo:rate5m: The rate of network receive drops over a 5-minute interval.
-//
-// Parameters:
-//   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
-//
-// Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+// The panel shows:
+// - Network packet drops per interface
+// - Drop rates across nodes
 func ClusterNodeNetworkSaturationBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Network Saturation (Drops Receive/Transmit)",
+		panel.Description("Shows network saturation through drop metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -380,30 +386,24 @@ func ClusterNodeNetworkSaturationBytes(datasourceName string, labelMatchers ...p
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }}"),
+				query.SeriesNameFormat("{{instance}} - Network - Received"),
 			),
 		),
 	)
 }
 
 // ClusterNodeNetworkUsageBytes creates a panel option for displaying the network utilization
-// (Bytes Receive/Transmit) of cluster nodes. It takes a datasource name and an optional list of Prometheus label
-// matchers as arguments. The panel includes a time series chart with a bytes per second format on the Y-axis
-// and a legend positioned at the bottom in table mode, showing the last calculated value. The PromQL
-// queries used calculate the rate of network bytes received and transmitted over a 5-minute interval.
+// (Bytes Receive/Transmit) of cluster nodes.
+// The panel uses the following Prometheus metrics:
+// - instance:node_network_receive_bytes_excluding_lo:rate5m: Network bytes received
+// - instance:node_network_transmit_bytes_excluding_lo:rate5m: Network bytes transmitted
 //
-// The following Prometheus metrics are used:
-// - instance:node_network_receive_bytes_excluding_lo:rate5m: The rate of network bytes received over a 5-minute interval.
-// - instance:node_network_transmit_bytes_excluding_lo:rate5m: The rate of network bytes transmitted over a 5-minute interval.
-//
-// Parameters:
-//   - datasourceName: The name of the Prometheus data source.
-//   - labelMatchers: A variadic parameter for Prometheus label matchers to filter the query.
-//
-// Returns:
-//   - panelgroup.Option: A panel option that can be added to a panel group.
+// The panel shows:
+// - Network throughput per interface
+// - Receive and transmit rates
 func ClusterNodeNetworkUsageBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Network Utilisation (Bytes Receive/Transmit)",
+		panel.Description("Shows network utilization in bytes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -423,7 +423,7 @@ func ClusterNodeNetworkUsageBytes(datasourceName string, labelMatchers ...promql
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }} Receive"),
+				query.SeriesNameFormat("{{instance}} - Network - Received"),
 			),
 		),
 		panel.AddQuery(
@@ -433,16 +433,23 @@ func ClusterNodeNetworkUsageBytes(datasourceName string, labelMatchers ...promql
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{ instance }} Transmit"),
+				query.SeriesNameFormat("{{instance}} - Network - Transmitted"),
 			),
 		),
 	)
 }
 
 // NodeAverage creates a panel group option for displaying CPU usage metrics.
-// It adds a time series panel with multiple Prometheus queries to visualize
-// the 1-minute, 5-minute, and 15-minute load averages, as well as the count
-// of logical CPU cores.
+//
+// The panel uses the following Prometheus metrics:
+// - node_load1: 1-minute load average
+// - node_load5: 5-minute load average
+// - node_load15: 15-minute load average
+// - node_cpu_seconds_total: CPU time in different modes
+//
+// The panel shows:
+// - Load averages over different time periods
+// - Number of logical CPU cores
 //
 // Parameters:
 //   - datasourceName: The name of the data source to be used for the queries.
@@ -452,6 +459,7 @@ func ClusterNodeNetworkUsageBytes(datasourceName string, labelMatchers ...promql
 //   - panelgroup.Option: The configured panel group option.
 func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("CPU Usage",
+		panel.Description("Shows CPU utilization metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
@@ -466,7 +474,7 @@ func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("1m load average"),
+				query.SeriesNameFormat("CPU - 1m Average"),
 			),
 		),
 		panel.AddQuery(
@@ -476,7 +484,7 @@ func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("5m load average"),
+				query.SeriesNameFormat("CPU - 5m Average"),
 			),
 		),
 		panel.AddQuery(
@@ -486,7 +494,7 @@ func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("15m load average"),
+				query.SeriesNameFormat("CPU - 15m Average"),
 			),
 		),
 		panel.AddQuery(
@@ -496,20 +504,21 @@ func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("logical cores"),
+				query.SeriesNameFormat("CPU - Logical Cores"),
 			),
 		),
 	)
 }
 
 // NodeMemoryUsageBytes creates a panel group option for displaying node memory usage in bytes.
-// It generates a time series panel with the following queries:
-// - Memory used: Total memory minus free, buffers, and cached memory.
-// - Memory buffers: Memory used for buffers.
-// - Memory cached: Memory used for caching.
-// - Memory free: Free memory.
+// The panel uses the following Prometheus metrics:
+// - node_memory_Buffers_bytes: Memory used for buffers
+// - node_memory_Cached_bytes: Memory used for cache
+// - node_memory_MemFree_bytes: Free memory available
 //
-// The panel includes a Y-axis formatted in bytes and a legend positioned at the bottom in table mode.
+// The panel shows:
+// - Memory usage breakdown by type (buffers, cached, free)
+// - Values in bytes
 //
 // Parameters:
 // - datasourceName: The name of the data source to be used for the queries.
@@ -519,6 +528,7 @@ func NodeAverage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 // - panelgroup.Option: The configured panel group option.
 func NodeMemoryUsageBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Memory Usage",
+		panel.Description("Shows memory utilization metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -535,21 +545,11 @@ func NodeMemoryUsageBytes(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(node_memory_MemTotal_bytes{job='node',instance='$instance'}-node_memory_MemFree_bytes{job='node',instance='$instance'}-node_memory_Buffers_bytes{job='node',instance='$instance'}-node_memory_Cached_bytes{job='node',instance='$instance'})",
-					labelMatchers,
-				),
-				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("memory used"),
-			),
-		),
-		panel.AddQuery(
-			query.PromQL(
-				promql.SetLabelMatchers(
 					"node_memory_Buffers_bytes{job='node', instance='$instance'}",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("memory buffers"),
+				query.SeriesNameFormat("Memory - Buffers"),
 			),
 		),
 		panel.AddQuery(
@@ -559,7 +559,7 @@ func NodeMemoryUsageBytes(datasourceName string, labelMatchers ...promql.LabelMa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("memory cached"),
+				query.SeriesNameFormat("Memory - Cached"),
 			),
 		),
 		panel.AddQuery(
@@ -569,19 +569,20 @@ func NodeMemoryUsageBytes(datasourceName string, labelMatchers ...promql.LabelMa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("memory free"),
+				query.SeriesNameFormat("Memory - Free"),
 			),
 		),
 	)
 }
 
-// NodeMemoryUsagePercentage creates a panel option for displaying the memory usage percentage of a node.
-// The panel is a gauge chart that shows the memory usage with thresholds set at 80% (orange) and 90% (red).
-// The function takes a datasource name and an optional list of Prometheus label matchers.
+// NodeMemoryUsagePercentage creates a panel option for displaying memory usage percentage.
+// The panel uses the following Prometheus metrics:
+// - node_memory_MemAvailable_bytes: Available memory in bytes
+// - node_memory_MemTotal_bytes: Total physical memory in bytes
 //
-// The following Prometheus metrics are used:
-// - node_memory_MemAvailable_bytes: The amount of memory available for starting new applications, without swapping.
-// - node_memory_MemTotal_bytes: The total amount of physical memory.
+// The panel shows:
+// - Memory usage percentage with thresholds
+// - Available vs total memory ratio
 //
 // Parameters:
 // - datasourceName: The name of the Prometheus datasource.
@@ -591,6 +592,7 @@ func NodeMemoryUsageBytes(datasourceName string, labelMatchers ...promql.LabelMa
 // - panelgroup.Option: The panel option for the memory usage gauge chart.
 func NodeMemoryUsagePercentage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Memory Usage",
+		panel.Description("Shows memory utilization across nodes"),
 		gauge.Chart(
 			gauge.Calculation(commonSdk.LastCalculation),
 			gauge.Format(commonSdk.Format{
@@ -618,25 +620,31 @@ func NodeMemoryUsagePercentage(datasourceName string, labelMatchers ...promql.La
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("memory used"),
+				query.SeriesNameFormat("Memory - Usage"),
 			),
 		),
 	)
 }
 
-// NodeDiskIOBytes creates a panel group option for displaying Disk I/O metrics in a time series chart.
-// The panel includes two Prometheus queries:
-// 1. "rate(node_disk_read_bytes_total{job='node', instance='$instance',device!=”}[5m])" - This metric tracks the rate of bytes read from disk.
-// 2. "rate(node_disk_io_time_seconds_total{job='node', instance='$instance',device!=”}[5m])" - This metric tracks the rate of I/O time in seconds.
+// NodeDiskIOBytes creates a panel option for displaying Disk I/O metrics.
+//
+// The panel uses the following Prometheus metrics:
+// - node_disk_read_bytes_total: Total number of bytes read from disk
+// - node_disk_io_time_seconds_total: Total seconds spent on I/O operations
+//
+// The panel shows:
+// - Rate of bytes read from disk per device
+// - I/O time per device
 //
 // Parameters:
-// - datasourceName: The name of the data source to be used for the Prometheus queries.
-// - labelMatchers: Optional Prometheus label matchers to filter the metrics.
+//   - datasourceName: The name of the data source.
+//   - labelMatchers: Optional Prometheus label matchers.
 //
 // Returns:
-// - panelgroup.Option: A configured panel group option for the Disk I/O metrics.
+//   - panelgroup.Option: The configured panel option.
 func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Disk I/O Bytes",
+		panel.Description("Shows disk I/O metrics in bytes"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -656,7 +664,7 @@ func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{device}} read"),
+				query.SeriesNameFormat("{{device}} - Disk - Usage"),
 			),
 		),
 		panel.AddQuery(
@@ -666,7 +674,7 @@ func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{device}} written"),
+				query.SeriesNameFormat("{{device}} - Disk - Written"),
 			),
 		),
 	)
@@ -674,19 +682,15 @@ func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher
 
 // NodeDiskIOSeconds creates a panel option for displaying Disk I/O time series data.
 //
-// The panel queries the Prometheus metric `node_disk_io_time_seconds_total`,
-// which measures the total time spent on I/O operations for each disk device.
-// The query applies a rate function over a 5-minute interval and filters the data
-// based on the provided label matchers.
+// The panel uses the following Prometheus metrics:
+// - node_disk_io_time_seconds_total: Total time spent on I/O operations
 //
-// Parameters:
-// - datasourceName: The name of the data source to be used for the query.
-// - labelMatchers: Optional Prometheus label matchers to filter the query results.
-//
-// Returns:
-// - A panelgroup.Option that adds the configured Disk I/O panel to a panel group.
+// The panel shows:
+// - I/O operation duration per device
+// - Time spent on disk operations
 func NodeDiskIOSeconds(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Disk I/O Seconds",
+		panel.Description("Shows disk I/O duration metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -706,16 +710,21 @@ func NodeDiskIOSeconds(datasourceName string, labelMatchers ...promql.LabelMatch
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{device}} io time"),
+				query.SeriesNameFormat("{{device}} - Disk - IO Time"),
 			),
 		),
 	)
 }
 
 // NodeNetworkReceivedBytes creates a panel option for displaying the rate of network received bytes
-// for nodes, excluding the loopback device. The panel is configured with a time series chart that
-// shows the data in bytes per second, and includes a legend positioned at the bottom in table mode,
-// displaying the last value.
+// for nodes, excluding the loopback device.
+//
+// The panel uses the following Prometheus metrics:
+// - node_network_receive_bytes_total: Total bytes received over network
+//
+// The panel shows:
+// - Network receive rate per interface
+// - Bandwidth utilization patterns
 //
 // Parameters:
 //   - datasourceName: The name of the data source to be used for the query.
@@ -725,6 +734,7 @@ func NodeDiskIOSeconds(datasourceName string, labelMatchers ...promql.LabelMatch
 //   - panelgroup.Option: The configured panel option.
 func NodeNetworkReceivedBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Network Received",
+		panel.Description("Shows network received bytes metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -744,15 +754,21 @@ func NodeNetworkReceivedBytes(datasourceName string, labelMatchers ...promql.Lab
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{device}}"),
+				query.SeriesNameFormat("{{device}} - Network - Received"),
 			),
 		),
 	)
 }
 
 // NodeNetworkTransmitedBytes creates a panel option for displaying the network transmitted bytes
-// for nodes. It configures a time series panel with specific Y-axis formatting, legend settings,
-// and a Prometheus query to fetch the data.
+// for nodes.
+//
+// The panel uses the following Prometheus metrics:
+// - node_network_transmit_bytes_total: Total bytes transmitted over network
+//
+// The panel shows:
+// - Network transmit rate per interface
+// - Bandwidth utilization patterns
 //
 // Parameters:
 //   - datasourceName: The name of the data source to be used for the query.
@@ -762,6 +778,7 @@ func NodeNetworkReceivedBytes(datasourceName string, labelMatchers ...promql.Lab
 //   - panelgroup.Option: A panel option that can be added to a panel group.
 func NodeNetworkTransmitedBytes(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Network Transmitted",
+		panel.Description("Shows network transmitted bytes metrics"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
@@ -781,7 +798,7 @@ func NodeNetworkTransmitedBytes(datasourceName string, labelMatchers ...promql.L
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{device}}"),
+				query.SeriesNameFormat("{{device}} - Network - Transmitted"),
 			),
 		),
 	)


### PR DESCRIPTION
This pull request includes several changes to improve the descriptions and formatting of panels in the `alertmanager` and `node_exporter` packages. The most important changes include updating URLs, adding detailed descriptions for Prometheus metrics, and refining query formats.

### Changes to `alertmanager` package:

* Updated descriptions to specify the Prometheus metrics used and the data shown in various panels. [[1]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beR17-R19) [[2]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beL40-R56) [[3]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beR104-R111) [[4]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beR155-R164)
* Refined the series name formats in queries to include more descriptive labels. [[1]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beL72-R81) [[2]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beL82-R91) [[3]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beL118-R135) [[4]](diffhunk://#diff-27c723a4f015acf2bd7ccb3dc051c81d42a2af63043a09dd2ea24b7f28bb52beL166-R193)

### Changes to `node_exporter` package:

* Added detailed descriptions for Prometheus metrics and the data shown in panels. [[1]](diffhunk://#diff-4551d6182eb82db5aab2b23f5520666951031b3b02108a5d750340996e977a79R18-R24) [[2]](diffhunk://#diff-4551d6182eb82db5aab2b23f5520666951031b3b02108a5d750340996e977a79L94-R113) [[3]](diffhunk://#diff-4551d6182eb82db5aab2b23f5520666951031b3b02108a5d750340996e977a79L137-R166) [[4]](diffhunk://#diff-4551d6182eb82db5aab2b23f5520666951031b3b02108a5d750340996e977a79L178-R203) [[5]](diffhunk://#diff-4551d6182eb82db5aab2b23f5520666951031b3b02108a5d750340996e977a79L226-R250)
* Updated the series name formats in queries to include more descriptive labels.

### Other changes:

* Updated the `directUrl` in `examples/perses/datasource.yaml` to a new URL.